### PR TITLE
[TK-723] doc: correct license

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Payment.init({ api_key: api-key, mode: 'sandbox' });
 ```
 
 Production mode (running on mainnet)
-**WARNING**: production mode is not ready for use in this beta version
 
 ```js
 import Payment from "@tokoinofficial/t-chain-payment";

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "main": "index.js",
     "name": "@tokoinofficial/t-chain-payment",
-    "license": "MIT",
-    "version": "2.0.1",
+    "license": "Apache-2.0",
+    "version": "2.0.2",
     "author": {
         "name": "tokoinofficial",
         "email": "hello@tokoin.io"


### PR DESCRIPTION
- Default license currently does not match with business.
  Change license to Apache-2.0 (https://spdx.org/licenses/)
- Update version to v2.0.2
- Minor fix in README: remove the warning about production mode, it's
  now ready for use.
